### PR TITLE
feat: GitHub ActionsでGitHub Pagesデプロイを設定 (#1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Build and Deploy
 
 on:
   push:
@@ -36,18 +36,24 @@ jobs:
     - name: Install dependencies
       run: pnpm install
 
+    - name: Lint
+      run: pnpm run lint
+
     - name: Build
       run: pnpm run build
 
     - name: Setup Pages
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: actions/configure-pages@v4
 
     - name: Upload artifact
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: actions/upload-pages-artifact@v3
       with:
         path: ./dist
 
   deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -30,6 +30,19 @@ jobs:
       uses: pnpm/action-setup@v2
       with:
         version: 8
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       run: pnpm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Build and Deploy
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read
@@ -31,7 +29,7 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:
-        version: latest
+        version: 8
 
     - name: Install dependencies
       run: pnpm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: latest
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Build
+      run: pnpm run build
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-  base: process.env.NODE_ENV === 'production' ? '/running-schedule-planner2/' : '/',
+  base: import.meta.env.PROD ? '/running-schedule-planner2/' : '/',
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  base: process.env.NODE_ENV === 'production' ? '/running-schedule-planner2/' : '/',
 })


### PR DESCRIPTION
## 概要
GitHub Actionsを使用してGitHub Pagesへの自動デプロイ機能を追加

Closes #1

## 変更内容
- `.github/workflows/deploy.yml` - GitHub Actionsワークフローファイルを追加
- `vite.config.ts` - GitHub Pages用のベースパス設定を追加

## 実装詳細
- mainブランチへのpush時に自動デプロイ
- pnpmを使用したビルドプロセス
- GitHub Pagesへの自動デプロイ設定

## デプロイ後の設定
プルリクエストマージ後、以下の設定が必要です：
1. リポジトリの Settings → Pages
2. Source を "GitHub Actions" に設定

## アクセスURL
デプロイ後: https://sugasaki.github.io/running-schedule-planner2/

## チェックリスト
- [x] GitHub Actionsワークフローファイルを作成
- [x] Vite設定でベースパスを設定
- [x] pnpmを使用したビルド設定
- [x] GitHub Pagesへのデプロイ設定