### PR TITLE
fix: Vite設定でcommandベースのbase設定に修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
   server: {
     port: 3000,
   },
-  base: import.meta.env.PROD ? '/running-schedule-planner2/' : '/',
-})
+  base: command === 'build' ? '/running-schedule-planner2/' : '/',
+}))


### PR DESCRIPTION
## 概要
GitHub ActionsでのViteビルドエラーを修正

## 問題
`import.meta.env.PROD`がVite設定ファイルで使用できず、ビルド時にエラーが発生していました。

## 解決方法
- `defineConfig`の関数形式を使用
- `command`パラメータでビルド/開発を判定
- `command === 'build'`でプロダクションビルドを検出

## 変更内容
- `vite.config.ts`で`import.meta.env.PROD`を`command === 'build'`に変更
- GitHub Pages用のベースパス設定を適切に動作するように修正

## テスト
- ローカルでの開発サーバー起動確認
- GitHub Actionsでのビルド成功確認

🤖 Generated with [Claude Code](https://claude.ai/code)